### PR TITLE
mrc-6200 Select dataset and admin level on test page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Run unit and integration tests with `npm run test`
 Run tests with coverage using `npm run coverage`
 
 Manual testing can be done by viewing [test.html](test.html) in the browser. Here you can choose to view any available dataset on
-either a local grout server, or deplayed to mrcdata. 
+either a local grout server, or deployed to mrcdata. 
 
 # Lint
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Run unit and integration tests with `npm run test`
 
 Run tests with coverage using `npm run coverage`
 
+Manual testing can be done by viewing [test.html](test.html) in the browser. Here you can choose to view any available dataset on
+either a local grout server, or deplayed to mrcdata. 
+
 # Lint
 
 Run lint with `npm run lint`. To do any possible automatic fixes run `npm run lint-fix`.

--- a/test.html
+++ b/test.html
@@ -26,19 +26,20 @@
                 z-index: 9999;
             }
             #app {
+                font-family: sans-serif;
+                font-size: 18px;
+                background-color: rgba(255, 255, 255, 0.7);
+                padding: 8px;
                 position: absolute;
                 right: 12px;
                 top: 12px;
                 z-index: 9999;
             }
             #dataset-select {
-                font-size: 22px;
+                font-size: 18px;
                 width: 100%;
             }
             #admin-radios {
-                background-color: rgba(255, 255, 255, 0.7);
-                font-family: sans-serif;
-                font-size: 18px;
                 margin-top: 6px;
                 padding: 6px;
             }
@@ -55,6 +56,7 @@
         <div id="map">
         </div>
         <div id="app">
+            <label for="dataset-select">Dataset</label>
             <select id="dataset-select" v-if="datasets" v-model="selectedDatasetName">
                 <option v-for="dataset in Object.keys(datasets)" :value="dataset">{{dataset}}</option>
             </select>

--- a/test.html
+++ b/test.html
@@ -5,6 +5,7 @@
         <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
         <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
         <script src="https://unpkg.com/leaflet-vector-tile-layer@0.16.1/dist/VectorTileLayer.umd.js"></script>
+        <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
         <style>
             #map {
                 width: 100vw;
@@ -24,17 +25,55 @@
                 font-size: 3rem;
                 z-index: 9999;
             }
+            #app {
+                position: absolute;
+                right: 12px;
+                top: 12px;
+                z-index: 9999;
+            }
+            #dataset-select {
+                font-size: 22px;
+                width: 100%;
+            }
+            #admin-radios {
+                background-color: rgba(255, 255, 255, 0.7);
+                font-family: sans-serif;
+                font-size: 18px;
+                margin-top: 6px;
+                padding: 6px;
+            }
+            input {
+                margin-right: 16px;
+            }
+            label {
+                vertical-align: middle;
+            }
         </style>
     </head>
     <body>
         <h1>GROUT Test Page</h1>
-        <div id="map"></div>
+        <div id="map">
+        </div>
+        <div id="app">
+            <select id="dataset-select" v-if="datasets" v-model="selectedDatasetName">
+                <option v-for="dataset in Object.keys(datasets)" :value="dataset">{{dataset}}</option>
+            </select>
+            <div id="admin-radios">
+                <label for="admin1">Admin 1</label>
+                <input type="radio" id="admin1" v-model="adminLevel" :value="1" />
+                <label for="admin2">Admin 2</label>
+                <input type="radio" id="admin2" v-model="adminLevel" :value="2" />
+            </div>
+        </div>
         <script>
             const map = L.map("map").setView({lon: 0, lat: 0}, 3);
             map.options.minZoom = 3;
 
             const nameProp = "NAME_1";
-            const groutUrl = "http://localhost:5000";
+            const groutServers = {
+                "local": "http://localhost:5000",
+                "mrcdata": "https://mrcdata.dide.ic.ac.uk/grout"
+            };
 
             // Background layer
             const attribution = "Tiles &copy; Esri &mdash; Esri, DeLorme, NAVTEQ; " +
@@ -50,8 +89,8 @@
                 tms: true, // y values are inverted without this!
             };
 
-            // Admin1 layer - assign shade of blue based on first letter of name!
-            const admin1Options = {
+            // Region layer options - assign shade of blue based on first letter of name!
+            const regionOptions = {
                 style: (feature, layerName) => {
                     const shade = Math.min((feature.properties[nameProp].charCodeAt(0) - 65)/26, 1) * 255;
                     return {
@@ -63,19 +102,9 @@
                 },
                 ...options
             };
-            VectorTileLayer(`${groutUrl}/tile/gadm41/admin1/{z}/{x}/{-y}`, admin1Options)
-                .on('mouseover', function(e) {
-                    // show a tooltip
-                    const name = e.layer.properties[nameProp];
-                    L.popup()
-                        .setContent(name)
-                        .setLatLng(e.latlng)
-                        .openOn(map);
-                })
-                .addTo(map);
 
-            // Admin0 layer
-            const admin0Options = {
+            // Country layer options
+            const countryOptions = {
                 style: {
                     weight: 1,
                     fill: false,
@@ -83,8 +112,75 @@
                 },
                 ...options
             };
-            VectorTileLayer(`${groutUrl}/tile/gadm41/admin0/{z}/{x}/{-y}`, admin0Options).addTo(map);
 
+            let regionLayer = null;
+            let countryLayer = null;
+
+            const { createApp, ref, onMounted, watch } = Vue;
+            createApp({
+                setup() {
+                    // Dict of friendly name to { url, dataset }
+                    const datasets = ref(null);
+                    const selectedDatasetName = ref("");
+                    const adminLevel = ref(1);
+
+                    onMounted(async () => {
+                        // Populate drop down with available datasets from both servers
+                        const fetchedDatasets = {};
+                        for (let server in groutServers) {
+                            const url = groutServers[server];
+                            const response = await fetch(`${url}/metadata`);
+                            const metadata = await response.json();
+                            if (metadata.status === "success") {
+                                const datasetNames = Object.keys(metadata.data.datasets.tile);
+                                datasetNames.forEach((dataset) => {
+                                    fetchedDatasets[`${server}: ${dataset}`] = { url, dataset };
+                                });
+                            }
+                        }
+                        datasets.value = fetchedDatasets;
+                        if (Object.keys(fetchedDatasets).length) {
+                            selectedDatasetName.value = Object.keys(fetchedDatasets)[0];
+                        }
+                    });
+
+                    watch([selectedDatasetName, adminLevel], () => {
+                        updateMap();
+                    });
+
+                    const updateMap = () => {
+                        if (regionLayer) {
+                            regionLayer.removeFrom(map);
+                        }
+                        if (countryLayer) {
+                            countryLayer.removeFrom(map);
+                        }
+
+                        const { url, dataset } = datasets.value[selectedDatasetName.value];
+                        const level = adminLevel.value;
+
+                        regionLayer = VectorTileLayer(`${url}/tile/${dataset}/admin${level}/{z}/{x}/{-y}`, regionOptions)
+                            .on('mouseover', function (e) {
+                                // show a tooltip
+                                const name = e.layer.properties[nameProp];
+                                L.popup()
+                                    .setContent(name)
+                                    .setLatLng(e.latlng)
+                                    .openOn(map);
+                            });
+                        regionLayer.addTo(map);
+
+                        countryLayer = VectorTileLayer(`${url}/tile/${dataset}/admin0/{z}/{x}/{-y}`, countryOptions);
+                        countryLayer.addTo(map);
+                    }
+
+                    return {
+                        datasets,
+                        selectedDatasetName,
+                        adminLevel
+                    }
+                }
+            }).mount('#app')
         </script>
     </body>
 </html>

--- a/test.html
+++ b/test.html
@@ -129,13 +129,18 @@
                         const fetchedDatasets = {};
                         for (let server in groutServers) {
                             const url = groutServers[server];
-                            const response = await fetch(`${url}/metadata`);
-                            const metadata = await response.json();
-                            if (metadata.status === "success") {
-                                const datasetNames = Object.keys(metadata.data.datasets.tile);
-                                datasetNames.forEach((dataset) => {
-                                    fetchedDatasets[`${server}: ${dataset}`] = { url, dataset };
-                                });
+                            try {
+                                const response = await fetch(`${url}/metadata`);
+                                const metadata = await response.json();
+                                if (metadata.status === "success") {
+                                    const datasetNames = Object.keys(metadata.data.datasets.tile);
+                                    datasetNames.forEach((dataset) => {
+                                        fetchedDatasets[`${server}: ${dataset}`] = {url, dataset};
+                                    });
+                                }
+                            }
+                            catch(e) {
+                                console.log(`Error fetching from ${url}: ${e}`);
                             }
                         }
                         datasets.value = fetchedDatasets;


### PR DESCRIPTION
This  branch adds functionality to the test page to allow selecting dataset from both localhost (if running locally) and mrcdata, so you can eyeball a grout tile dataset to see if it actually works. You can also toggle admin1 or admin2 level. 

I've added a simple Vue app, which on mount fetches metadata from both servers, and adds datasets to a select (options are prefixed with 'local' or 'mrcdata'). There are radio buttons to select admin level 1 or 2 - admin levels are available in the metadata but for now we're assuming that `admin1` and `admin2` are defined. `admin0` is still used to draw country boundaries. 

This means that this page should now be useful both for development testing of the grout server code, and also to check that datasets are working. So it's probably going to be useful to add it to the grout deploy itself so it can be used for testing without needing to have the grout repo checked out. I'll do that in a separate grout deploy ticket. 

Just open the page in the browser. You should see that mrcdata now has "arbomap" and "gadm41" datasets. 

If this page gets much more complicated, we should probably convert it into a built Typescript app, but for now it's just plain old HTML + js...