### PR TITLE
mrc-6834 Switch on eslint rule no-unused-vars

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,7 +24,12 @@ export default [
             "no-shadow": "off",
             "@typescript-eslint/no-shadow": ["off"],
             "no-underscore-dangle": "off",
-            "no-unused-vars": "off",
+            "no-unused-vars": [
+                "error",
+                {
+                    argsIgnorePattern: "_"
+                }
+            ],
             "@typescript-eslint/no-unused-vars": ["error"],
             "no-await-in-loop": "off",
             "no-useless-concat": "off",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,7 +27,7 @@ export default [
             "no-unused-vars": [
                 "error",
                 {
-                    argsIgnorePattern: "_"
+                    argsIgnorePattern: "^_"
                 }
             ],
             "@typescript-eslint/no-unused-vars": ["error"],

--- a/src/errors/errorType.ts
+++ b/src/errors/errorType.ts
@@ -1,9 +1,10 @@
-export const enum ErrorType {
-    BAD_REQUEST = "BAD_REQUEST",
-    NOT_FOUND = "NOT_FOUND",
-    UNEXPECTED_ERROR = "UNEXPECTED_ERROR"
+export enum ErrorType {
+    BAD_REQUEST = "BAD_REQUEST", // eslint-disable-line no-unused-vars
+    NOT_FOUND = "NOT_FOUND", // eslint-disable-line no-unused-vars
+    UNEXPECTED_ERROR = "UNEXPECTED_ERROR" // eslint-disable-line no-unused-vars
 }
 
+// eslint-disable-next-line no-unused-vars
 export const ErrorTypeStatuses: { [key in ErrorType]: number } = {
     [ErrorType.BAD_REQUEST]: 400,
     [ErrorType.NOT_FOUND]: 404,

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -15,7 +15,7 @@ export const initialiseLogging = (app: Application) => {
     morgan.token("error-stack", (req: RequestWithError) => req.errorStack);
 
     const customFormat = (
-        tokens: Dict<(req: Request, res?: Response, header?: string) => string>,
+        tokens: Dict<(_: Request, _?: Response, _?: string) => string>,
         req: Request,
         res: Response
     ) => {

--- a/tests/integration/errors.spec.ts
+++ b/tests/integration/errors.spec.ts
@@ -1,6 +1,5 @@
-import { describe, expect, test, beforeAll, afterAll } from "vitest";
+import { describe, expect, test } from "vitest";
 import { grout, validateResponse } from "./integrationTest";
-import * as fs from "fs";
 
 const expect404Response = async (url: string) => {
     const response = await grout.get(url);

--- a/tests/integration/region_metadata.spec.ts
+++ b/tests/integration/region_metadata.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { getData, grout } from "./integrationTest";
+import { getData } from "./integrationTest";
 
 describe("region metadata endpoints", () => {
     test("returns global level 0 metadata", async () => {

--- a/tests/unit/controllers/regionMetadataController.spec.ts
+++ b/tests/unit/controllers/regionMetadataController.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test, vi, beforeEach } from "vitest";
 import { fs, vol } from "memfs";
 import * as jsonResponse from "../../../src/jsonResponse";
-import { jsonResponseSuccess } from "../../../src/jsonResponse";
 import { RegionMetadataController } from "../../../src/controllers/regionMetadataController";
 
 // tell vitest to use fs mock from __mocks__ folder

--- a/tests/unit/controllers/tileController.spec.ts
+++ b/tests/unit/controllers/tileController.spec.ts
@@ -15,7 +15,7 @@ const mockTileData = "some fake tile data";
 const mockDb = {
     getTileData: vi
         .fn()
-        .mockImplementation(async (z, x, y) => (z === 0 ? null : mockTileData))
+        .mockImplementation(async (z, _, _) => (z === 0 ? null : mockTileData))
 };
 const mockRequest = {
     params,

--- a/tests/unit/controllers/tileController.spec.ts
+++ b/tests/unit/controllers/tileController.spec.ts
@@ -15,7 +15,9 @@ const mockTileData = "some fake tile data";
 const mockDb = {
     getTileData: vi
         .fn()
-        .mockImplementation(async (z, _, _) => (z === 0 ? null : mockTileData))
+        .mockImplementation(async (z, _x, _y) =>
+            z === 0 ? null : mockTileData
+        )
 };
 const mockRequest = {
     params,

--- a/tests/unit/errors/asyncControllerHandler.spec.ts
+++ b/tests/unit/errors/asyncControllerHandler.spec.ts
@@ -20,6 +20,7 @@ describe("asyncControllerHandler", () => {
     test("does not call next if no error thrown by controller method", async () => {
         const method = async () => {
             const s = 1 + 1;
+            console.log(s);
         };
         await asyncControllerHandler(mockNext, method);
         expect(mockNext).not.toHaveBeenCalled();

--- a/tests/unit/errors/groutError.spec.ts
+++ b/tests/unit/errors/groutError.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi, beforeEach } from "vitest";
+import { describe, expect, test } from "vitest";
 import { GroutError } from "../../../src/errors/groutError";
 import { ErrorType } from "../../../src/errors/errorType";
 

--- a/tests/unit/errors/notFound.spec.ts
+++ b/tests/unit/errors/notFound.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi, beforeEach } from "vitest";
+import { describe, expect, test } from "vitest";
 import notFound from "../../../src/errors/notFound";
 import { ErrorType } from "../../../src/errors/errorType";
 

--- a/tests/unit/logging.spec.ts
+++ b/tests/unit/logging.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import { initialiseLogging } from "../../src/logging";
 
-const { mockMorganResult, mockMorgan, mockToken } = vi.hoisted(() => {
+const { mockMorganResult, mockMorgan } = vi.hoisted(() => {
     const mockMorganResult = { morgan: "mock result" };
     const mockMorgan = vi.fn().mockImplementation(() => mockMorganResult);
     const mockToken = vi.fn();
@@ -52,9 +52,9 @@ describe("initialiseLogging", () => {
             res: (req: any, res: any, name: string) =>
                 `${req.res}:${res.res}:${name}`,
             "response-time": (req: any, res: any) => `${req.time}:${res.time}`,
-            "error-type": (req: any, res: any) => req.errorType,
-            "error-detail": (req: any, res: any) => req.errorDetail,
-            "error-stack": (req: any, res: any) => req.errorStack
+            "error-type": (req: any, _: any) => req.errorType,
+            "error-detail": (req: any, _: any) => req.errorDetail,
+            "error-stack": (req: any, _: any) => req.errorStack
         };
 
         const expectedLog =

--- a/tests/unit/server/buildMetadata.spec.ts
+++ b/tests/unit/server/buildMetadata.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi, beforeEach } from "vitest";
+import { describe, expect, test } from "vitest";
 import { buildMetadata } from "../../../src/server/buildMetadata";
 
 describe("buildMetadata", () => {


### PR DESCRIPTION
It makes sense to have this rule enabled. There were several failures in the codebase, mostly:
- unused imports in tests
- definitions of parameters in methods matching a particular sig, which were then not used - I've added an ignorable pattern for parameter names starting with `_` so that the rule does not trigger in this case. 
- annoyingly, the rule triggers for enum with values initialised (the enum values themselves are used however)